### PR TITLE
Discard duplicates in anagram solver

### DIFF
--- a/snap-server/src/main/java/com/kyc/snap/cromulence/CromulenceSolver.java
+++ b/snap-server/src/main/java/com/kyc/snap/cromulence/CromulenceSolver.java
@@ -14,9 +14,11 @@ import com.kyc.snap.words.DictionaryManager;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -86,10 +88,17 @@ public class CromulenceSolver {
             while (bestFinalStates.size() > NUM_RESULTS)
                 bestFinalStates.pollLastEntry();
         }
-        return bestFinalStates.stream()
-            .limit(NUM_RESULTS)
-            .map(state -> new CromulenceSolverResult(state.words, state.score))
-            .collect(Collectors.toList());
+        Set<List<String>> seenWords = new HashSet<>();
+        List<CromulenceSolverResult> results = new ArrayList<>();
+        for (State state : bestFinalStates) {
+            if (seenWords.contains(state.words))
+                continue;
+            seenWords.add(state.words);
+            results.add(new CromulenceSolverResult(state.words, state.score));
+            if (results.size() == NUM_RESULTS)
+                break;
+        }
+        return results;
     }
 
     private double approxScoreThreshold(List<State> states) {

--- a/snap-server/src/main/java/com/kyc/snap/cromulence/TermNodes.java
+++ b/snap-server/src/main/java/com/kyc/snap/cromulence/TermNodes.java
@@ -22,6 +22,7 @@ import com.kyc.snap.cromulence.TermStates.QuoteState;
 import com.kyc.snap.cromulence.TermStates.SymbolState;
 import com.kyc.snap.cromulence.TermStates.TermState;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Data;
 
@@ -64,7 +65,7 @@ class TermNodes {
 
     @Data
     static class ChoiceNode implements TermNode {
-        final List<TermNode> children;
+        final Set<TermNode> children;
 
         @Override
         public int complexity() {
@@ -166,7 +167,7 @@ class TermNodes {
         if (context instanceof ChoiceContext) {
             return new ChoiceNode(((ChoiceContext) context).terms().term().stream()
                 .map(TermNodes::fromAntlr)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toSet()));
         }
         if (context instanceof CountContext) {
             CountContext countContext = (CountContext) context;
@@ -186,7 +187,7 @@ class TermNodes {
         }
         if (context instanceof OrContext) {
             OrContext orContext = (OrContext) context;
-            return new ChoiceNode(List.of(fromAntlr(orContext.term(0)), fromAntlr(orContext.term(1))));
+            return new ChoiceNode(Set.of(fromAntlr(orContext.term(0)), fromAntlr(orContext.term(1))));
         }
         if (context instanceof QuoteContext) {
             return new QuoteNode(((QuoteContext) context).terms().term().stream()

--- a/snap-server/src/main/java/com/kyc/snap/cromulence/TermStates.java
+++ b/snap-server/src/main/java/com/kyc/snap/cromulence/TermStates.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Data;
@@ -124,7 +125,7 @@ class TermStates {
     static class ChoiceState implements TermState {
 
         final TermState parent;
-        final List<TermNode> children;
+        final Set<TermNode> children;
         final boolean used;
 
         @Override

--- a/snap-server/src/test/java/com/kyc/snap/cromulence/CromulenceSolverTest.java
+++ b/snap-server/src/test/java/com/kyc/snap/cromulence/CromulenceSolverTest.java
@@ -79,4 +79,13 @@ public class CromulenceSolverTest {
         assertThat(result.getWords()).containsExactly("THE", "LARGEST", "NATURAL", "BODY", "OF", "LAND", "IN", "ICE",
             "WATER");
     }
+
+    @Test
+    public void testSolveNoDuplicates() {
+        List<CromulenceSolverResult> result = cromulence.solve("[BC][AA]T", null);
+        assertThat(result)
+            .extracting(CromulenceSolverResult::getWords)
+            .contains(List.of("BAT"), List.of("CAT"))
+            .doesNotHaveDuplicates();
+    }
 }


### PR DESCRIPTION
Fix #22

- We can remove duplicates from choice terms immediately (e.g. `[APPLE] -> [APLE]`).
- There are several other ways that duplicate words can show up in the final list - remove those.