### PR TITLE
Monospace, justify, wrap cells in crossword exporter

### DIFF
--- a/snap-server/src/main/java/com/kyc/snap/crossword/CrosswordSpreadsheetWrapper.java
+++ b/snap-server/src/main/java/com/kyc/snap/crossword/CrosswordSpreadsheetWrapper.java
@@ -33,6 +33,7 @@ public class CrosswordSpreadsheetWrapper {
     private static final int MARKER_COL = 25;
     private static final int[] DROW = { 0, 1 };
     private static final int[] DCOL = { 1, 0 };
+    private static final String MONOSPACE_FONT = "Roboto Mono";
 
     private final SpreadsheetManager spreadsheets;
     private final int rowOffset;
@@ -104,12 +105,18 @@ public class CrosswordSpreadsheetWrapper {
                     allCharsExpression,
                     references.get(p))));
         }
-
+        
+        spreadsheets.setFont(rowOffset, grid.getNumRows(), colOffset, grid.getNumCols(), MONOSPACE_FONT);
+        spreadsheets.setTextAlignment(rowOffset, grid.getNumRows(), colOffset, grid.getNumCols(), "CENTER", "MIDDLE");
         spreadsheets.setProtectedRange(rowOffset, grid.getNumRows(), colOffset, grid.getNumCols());
         for (int i = 0; i < clues.getSections().size(); i++) {
             int numRows = clues.getSections().get(i).getClues().size();
             if (numRows > 0)
                 spreadsheets.setProtectedRange(0, numRows, directionColumns.get(i), 2);
+            	// Ensure that any long clues are auto-wrapped
+            	spreadsheets.setWrapStrategy(0, numRows, directionColumns.get(i), 1, "WRAP");
+            	// Format columns for enumerations and user-input to monospace
+            	spreadsheets.setFont(0, numRows, directionColumns.get(i) + 1, 2, MONOSPACE_FONT);
         }
 
         spreadsheets.setValues(valueCells);

--- a/snap-server/src/main/java/com/kyc/snap/google/SpreadsheetManager.java
+++ b/snap-server/src/main/java/com/kyc/snap/google/SpreadsheetManager.java
@@ -36,10 +36,12 @@ import com.google.api.services.sheets.v4.model.GridData;
 import com.google.api.services.sheets.v4.model.GridRange;
 import com.google.api.services.sheets.v4.model.InsertDimensionRequest;
 import com.google.api.services.sheets.v4.model.ProtectedRange;
+import com.google.api.services.sheets.v4.model.RepeatCellRequest;
 import com.google.api.services.sheets.v4.model.Request;
 import com.google.api.services.sheets.v4.model.RowData;
 import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.TextFormat;
 import com.google.api.services.sheets.v4.model.UpdateBordersRequest;
 import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
 import com.google.api.services.sheets.v4.model.UpdateDimensionPropertiesRequest;
@@ -308,6 +310,53 @@ public class SpreadsheetManager {
                         .setColor(toColor(cell.leftBorder.getRgb())))
                     .setRange(getRange(cell.row, cell.col))))
             .collect(Collectors.toList()));
+    }
+    
+    public void setTextAlignment(int rowIndex, int numRows, int colIndex, int numCols, String horizontalAlignment, String verticalAlignment) {
+    	executeRequests(new Request()
+                .setRepeatCell(new RepeatCellRequest()
+                    .setRange(new GridRange()
+                            .setSheetId(sheetId)
+                            .setStartRowIndex(rowIndex)
+                            .setEndRowIndex(rowIndex + numRows)
+                            .setStartColumnIndex(colIndex)
+                            .setEndColumnIndex(colIndex + numCols))
+                    .setCell(new CellData()
+                    		.setUserEnteredFormat(new CellFormat()
+                    				.setHorizontalAlignment(horizontalAlignment)
+                    				.setVerticalAlignment(verticalAlignment)))
+                    .setFields("userEnteredFormat(horizontalAlignment,verticalAlignment)")));
+    }
+    
+    public void setWrapStrategy(int rowIndex, int numRows, int colIndex, int numCols, String wrapStrategy) {
+    	executeRequests(new Request()
+                .setRepeatCell(new RepeatCellRequest()
+                    .setRange(new GridRange()
+                            .setSheetId(sheetId)
+                            .setStartRowIndex(rowIndex)
+                            .setEndRowIndex(rowIndex + numRows)
+                            .setStartColumnIndex(colIndex)
+                            .setEndColumnIndex(colIndex + numCols))
+                    .setCell(new CellData()
+                    		.setUserEnteredFormat(new CellFormat()
+                    				.setWrapStrategy(wrapStrategy)))
+                    .setFields("userEnteredFormat.wrapStrategy")));
+    }
+    
+    public void setFont(int rowIndex, int numRows, int colIndex, int numCols, String fontFamily) {
+    	executeRequests(new Request()
+                .setRepeatCell(new RepeatCellRequest()
+                    .setRange(new GridRange()
+                            .setSheetId(sheetId)
+                            .setStartRowIndex(rowIndex)
+                            .setEndRowIndex(rowIndex + numRows)
+                            .setStartColumnIndex(colIndex)
+                            .setEndColumnIndex(colIndex + numCols))
+                    .setCell(new CellData()
+                    		.setUserEnteredFormat(new CellFormat()
+                    				.setTextFormat(new TextFormat()
+                    						.setFontFamily(fontFamily))))
+                    .setFields("userEnteredFormat.textFormat.fontFamily")));
     }
 
     /**


### PR DESCRIPTION
I've found that these formatting changes are almost always manually done when work starts on the puzzle.
* Monospace and center letters in grid cells
* Monospace enumerations and user-input cells, auto-wrap long clues

![image](https://user-images.githubusercontent.com/5514270/148666142-5672514c-05cd-4187-8db2-e3648e8ec34f.png)

(Feel free to reject if you think this is too gimmicky and should be left as a manual process)