### PR TITLE
Prevent empty strings in word lengths field

### DIFF
--- a/snap-app/src/solver/solver.js
+++ b/snap-app/src/solver/solver.js
@@ -182,7 +182,7 @@ class Solver extends React.Component {
         postJson({
             path: '/words/cromulence', body: {
                 parts: query.split(/[ ,]+/),
-                wordLengths: wordLengths.length > 0 ? wordLengths.split(/[^0-9]+/) : undefined,
+                wordLengths: wordLengths.length > 0 ? wordLengths.trim().split(/[^0-9]+/) : undefined,
                 canRearrange,
             }
         }, ({ results }) => this.setState({ results, loading: false }));


### PR DESCRIPTION
Hitting "solve" when there are leading spaces or trailing spaces/commas produces errors. I just thought it would be slightly more convenient for users if we stripped their input instead of summoning an error alert box.