### PR TITLE
[Anagrammer] Support efficient anagram question mark queries

### DIFF
--- a/snap-app/src/solver/solver.js
+++ b/snap-app/src/solver/solver.js
@@ -142,7 +142,7 @@ class Solver extends React.Component {
                         </tr> : undefined}
                         {results.map(({ words, score }) => <tr>
                             <td>{words.join(' ')}</td>
-                            <td>{(score + 100).toFixed(2)}</td>
+                            <td>{score.toFixed(2)}</td>
                         </tr>)}
                     </tbody>
                 </table>

--- a/snap-server/src/test/java/com/kyc/snap/cromulence/CromulenceSolverTest.java
+++ b/snap-server/src/test/java/com/kyc/snap/cromulence/CromulenceSolverTest.java
@@ -81,9 +81,17 @@ public class CromulenceSolverTest {
     @Test
     public void testSolveRearrangementWithIncompleteLengths() {
         CromulenceSolverResult result = cromulence.solve(
-            "<(AR)(EL)(EM)(EN)(EN)(ET)(GT)(HI)(HS)(IT)(NC)(NG)(OM)(PL)(RA)(RE)(TW)",
+            "<(AR)(EL)(EM)(EN)(EN)(ET)(GT)(HI)(HS)(IT)(NC)(NG)(OM)(PL)(RA)(RE)(TW)>",
             List.of(13, 4)).get(0);
         assertThat(result.getWords()).containsExactly("REARRANGEMENT", "WITH");
+    }
+
+    @Test
+    public void testSolveRearrangementWithQuestionMarks() {
+        CromulenceSolverResult result = cromulence.solve(
+            "<(MEN)?(NGE)?(NMA)?(REA)?(RKS)?(RRA)?(THQ)?(TIO)?(TWI)?(UES)?>",
+            null).get(0);
+        assertThat(result.getWords()).containsExactly("REARRANGEMENT", "WITH", "QUESTION", "MARKS");
     }
 
     @Test


### PR DESCRIPTION
Hopefully fixes #35 

The current implementation is heinous for queries of the form `anagram(A?, B?, C?, ...)`. It tries all N! permutations of all children being empty. (If there are no question marks, then each iteration will add at least one letter, and the algorithm will prune bad branches, resulting in expected linear time.)

To fix this, we add a quick optimization that all empty children must be last in the anagram.

To make the `anagram(A?, B?, C?, ...)` query actually useful, we need to ensure results of different lengths are compared reasonably with each other. Currently, small common words like 'A' or 'MEN' will show up before less common words like 'REARRANGEMENT'. So we add a small boost for each additional letter.

Other miscellaneous thoughts:
- The boost value of '2' is found empirically.
- The interleave operator probably has this same problem, but I'm not going to bother with it here since it's a beta feature.
- An alternate fix is to change the pruning logic, which is currently a randomized algorithm that doesn't prune anything if all states' scores are 0. We could sort and limit instead. But I've profiled this before and it makes all queries noticeably slower. Also it doesn't fix the problem well, because the states with score 0 would still take up space in the bfs traversal.
