### PR TITLE
Improve word search solver and UI

### DIFF
--- a/snap-app/src/wordsearch/wordsearch.css
+++ b/snap-app/src/wordsearch/wordsearch.css
@@ -1,16 +1,25 @@
 .wordsearch .grid {
     width: 100%;
-    height: calc(100vh - 400px);
+    height: calc(100vh - 450px);
 }
 
-.wordsearch .wordbank {
+.wordsearch .word-bank {
     width: 100%;
     height: 150px;
+}
+
+.wordsearch .input table td {
+    text-align: center;
+    font-family: monospace;
+    font-size: 17px;
+    height: 20px;
+    width: 20px;
 }
 
 .wordsearch .output {
     height: calc(100vh - 150px);
     overflow: scroll;
+    user-select: none;
 }
 
 .wordsearch .output .link {
@@ -23,31 +32,12 @@
     width: 180px;
 }
 
-.wordsearch .output .link.in-wordbank {
-    border-color: #fbdfa3;
-}
-
-.wordsearch .hovering {
-    background-color: #cccccc;
-}
-
-.wordsearch .grid .in-wordbank {
-    background-color: #fbdfa3;
-}
-
-.wordsearch .in-wordbank.hovering {
-    background-color: #f9ce70;
-}
-
-.wordsearch .input table td {
-    text-align: center;
-    font-family: monospace;
-    font-size: 17px;
-    height: 20px;
-    width: 20px;
-}
-
-.wordsearch .unused {
+.wordsearch .unused-letters {
     font-family: monospace;
     width: 400px;
+    height: 100px;
+}
+
+.wordsearch input[type=button] {
+    margin-right: 2px;
 }

--- a/snap-app/src/wordsearch/wordsearch.js
+++ b/snap-app/src/wordsearch/wordsearch.js
@@ -1,4 +1,3 @@
-import classNames from "classnames";
 import React from "react";
 import { postJson } from "../fetch";
 import "./wordsearch.css";
@@ -9,17 +8,21 @@ export default class Wordsearch extends React.Component {
         super(props);
         this.state = {
             editMode: true,
-            grid: '',
-            wordbank: '',
-            boggle: false,
-            results: [],
-            highlightedIndex: undefined,
-            highlightedPositions: {},
-            highlightedWords: {},
-            highlightingAllWordbank: false,
-            highlightingDifferentColors: false,
-
             loading: false,
+            loadingClipboard: false,
+
+            /* inputs */
+            grid: '',
+            wordBank: '',
+            boggle: false,
+            fuzzy: false,
+
+            /* output state */
+            results: [],
+            hitLimit: false,
+            selectedIds: [],
+            hoveringId: undefined,
+            isAdd: undefined, /* if not undefined, whether currently adding or removing selected indices */
         };
     }
 
@@ -31,215 +34,276 @@ export default class Wordsearch extends React.Component {
     }
 
     render() {
-        const {
-            editMode,
-            boggle,
-            results,
-            highlightedIndex,
-            highlightedPositions,
-            highlightedWords,
-            highlightingAllWordbank,
-            highlightingDifferentColors,
-            loading
-        } = this.state;
-        const grid = this.getGrid();
+        const { editMode, results, selectedIds, hoveringId } = this.state;
+
+        const gridSquareColors = {};
+        const wordColors = {};
+        for (const selectedId of selectedIds) {
+            const{ path, word } = results.find(result => result.id === selectedId)
+            let hash = 0;
+            for (let i = 0; i < word.length; i++) {
+                hash = word.charCodeAt(i) + ((hash << 5) - hash);
+            }
+            const color = `hsl(${hash % 359}, 50%, 85%)`;
+
+            for (const { x, y } of path) {
+                if (gridSquareColors[`${x}-${y}`] === undefined) {
+                    gridSquareColors[`${x}-${y}`] = color;
+                }
+            }
+            wordColors[selectedId] = color;
+        }
+        if (hoveringId !== undefined) {
+            const { path } = results.find(result => result.id === hoveringId)
+            path.forEach(({ x, y }) => gridSquareColors[`${x}-${y}`] = '#f9ce70');
+            wordColors[hoveringId] = '#f9ce70';
+        }
+
         return <div className="wordsearch">
             <div className="input">
-                {editMode ? <>
-                    <div>
-                        {"Enter wordsearch grid (spaces are ignored): "}
-                        <input
-                            type="button"
-                            value="Demo"
-                            onClick={() => this.setState({
-                                grid: 'OHQRECTANGLEP\nDVQIMHESQWRAK\nICAVULQNTHRKO\nOPXLQUOROAINN\n'
-                                    + 'ZNPPAGIMLCHYO\nERURAABLHREDG\nPYETNUEZEFXSA\nAICGSLCDEHAPT\n'
-                                    + 'ROLPOINYBEGHN\nTELGRIPHUIOEE\nSURCLATYCONRP\nGALYLMECRJAEK\nMECZHFDIMARYP',
-                                wordbank: '',
-                                boggle: false
-                            })}
-                        />
-                    </div>
-                    <textarea className="grid"
-                        onChange={e => this.setState({ grid: e.target.value })}
-                        value={this.state.grid}
-                    />
-                    <div>
-                        {"Optional word bank (split by tab and/or newline; non-alphanumeric chars ignored): "}
-                        <input
-                            type="button"
-                            value="Demo"
-                            onClick={() => this.setState({
-                                grid: 'MENIMDLORAIREIMMUSKD\nWALUIGIGSOPAWTAADALH\nTERRNAEEWATOELRETTEC\n'
-                                    + 'ROIRODRIBYSFORIPOMEA\nANDILETTOPEACROFEINE\nCDRTPAMYWOCLHGTUEAHB\n'
-                                    + 'EANILASORSACLASATOCP\nWDFLSERYORNDORSSPEAH\nAYBOWSACTTOLVDENEOCB\n'
-                                    + 'PSRESSFFLEDAEKPIPOOO\nYSIADSEIOTESLSDGPIPK\nCROGDTONHFSONBNITOIU\n'
-                                    + 'ASTLAFSIOSETROMURGTC\nLIPEOSQOOBOTKEPLDAMR\nESEDSTUORRYYEFSDVIGI\n'
-                                    + 'RINRERAIDTERERNWVSYC\nTOADAIOCOKTGDSASOCNI\nHOSIUCTMNCKMOULTEBRE\n'
-                                    + 'RILLSEEOUSDLKINGBOOH\nDRREOTDTMALENRITAINS',
-                                wordbank: [
-                                    "Luigi Circuit", "Mario Circuit", "Daisy Circuit", "Dry Dry Ruins",
-                                    "Moo Moo Meadows", "Coconut Mall", "Koopa Cape", "Moonview Highway",
-                                    "Mushroom Gorge", "DK Summit", "Maple Treeway", "Bowser's Castle",
-                                    "Toad's Factory", "Wario's Gold Mine", "Grumble Volcano", "Rainbow Road",
-                                    "Peach Beach", "Sherbet Land", "Desert Hills", "Mario Circuit", "Yoshi Falls",
-                                    "Shy Guy Beach", "Bowser Castle", "Peach Gardens", "Ghost Valley",
-                                    "Delfino Square", "DK's Jungle Parkway", "DK Mountain", "Mario Raceway",
-                                    "Waluigi Stadium", "Mario Circuit", "Bowser's Castle"
-                                ].join('\t'),
-                                boggle: true
-                            })}
-                        />
-                    </div>
-                    <textarea className="wordbank"
-                        onChange={e => this.setState({ wordbank: e.target.value })}
-                        value={this.state.wordbank}
-                    />
-                    <div className="block">
-                        <input type="radio" checked={!boggle} onChange={() => this.setState({ boggle: !boggle })} />Straight
-                        <input type="radio" checked={boggle} onChange={() => this.setState({ boggle: !boggle })} />Boggle
-                    </div>
-                    <input
-                        type="button"
-                        value="Solve Wordsearch"
-                        onClick={this.solve}
-                    />
-                    <br />
-                    {loading ? <span className="loading" /> : undefined}
-                </> : <>
-                        <div className="block">
-                            <span
-                                className="button"
-                                onClick={() => {
-                                    this.setState({ editMode: true, results: [], highlightedIndex: undefined, highlightedPositions: undefined });
-                                    window.location.hash = '';
-                                }}
-                            >
-                                {"< Edit grid"}
-                            </span><br/><br/>
-                            {results.find(result => result.inWordBank) && <>
-                            <input
-                                type="checkbox"
-                                checked={highlightingAllWordbank}
-                                onChange={() => this.setState({ highlightingAllWordbank: !highlightingAllWordbank }, this.onHighlightWordbankChange)}
-                            />
-                            {"Highlight all word bank"}
-                            {highlightingAllWordbank && <>
-                            <input
-                                type="checkbox"
-                                checked={highlightingDifferentColors}
-                                onChange={() => this.setState({ highlightingDifferentColors: !highlightingDifferentColors }, this.onHighlightWordbankChange)}
-                            />
-                            {"Highlight different colors"}
-                            </>}
-                            </>
-                            }
-                        </div>
-                        <table className="block">
-                            <tbody>
-                                {grid.map((row, y) => <tr key={y}>
-                                    {[...row].map((c, x) => <td
-                                        key={x}
-                                        className={classNames({
-                                            hovering: highlightedPositions[`${x}-${y}`] !== undefined,
-                                            "in-wordbank": highlightedPositions[`${x}-${y}`]?.inWordBank
-                                        })}
-                                        style={{ backgroundColor: highlightedPositions[`${x}-${y}`]?.color }}
-                                    >
-                                        {c}
-                                    </td>)}
-                                </tr>)}
-                            </tbody>
-                        </table>
-                        {highlightingAllWordbank && <>
-                            <p>Unused letters: </p>
-                            <textarea className="unused"
-                                readOnly={true}
-                                value={grid.flatMap((row, y) => [...row].filter((c, x) => highlightedPositions[`${x}-${y}`] === undefined)).join('')}
-                            />
-                        </>
-                        }
-                </>}
+                {editMode ? this.renderEditingGrid() : this.renderSolvedGrid(gridSquareColors)}
             </div>
-            <div className="output">
-                {results.map(({ word, positions, inWordBank }, index) => <div
-                    key={index}
-                    className={classNames("link", { hovering: index === highlightedIndex, "in-wordbank": inWordBank })}
-                    style={{ backgroundColor: highlightedWords[index]?.color }}
-                    onMouseEnter={() => {
-                        if (!highlightingAllWordbank) {
-                            const highlightedPositions = {};
-                            const highlightedWords = {};
-                            for (const { x, y } of positions) {
-                                highlightedPositions[`${x}-${y}`] = { inWordBank };
-                            }
-                            this.setState({ highlightedIndex: index, highlightedPositions, highlightedWords });
-                        }
-                    }}
-                >{word}</div>)}
-            </div>
+            {!editMode && this.renderWordList(wordColors)}
         </div>;
     }
 
-    hashLocation() {
-        const { grid, wordbank, boggle, highlightingAllWordbank, highlightingDifferentColors } = this.state;
-        window.location.hash = btoa(JSON.stringify({ grid, wordbank, boggle, highlightingAllWordbank, highlightingDifferentColors }));
+    renderEditingGrid() {
+        const { loading, boggle, fuzzy } = this.state;
+
+        return <>
+            <div>
+                {"Enter word search grid (whitespace ignored): "}
+                <input
+                    type="button"
+                    value="Demo"
+                    onClick={() => this.setState({
+                        grid:
+                            "OHQRECTANGLEP\nDVQIMHESQWRAK\nICAVULQNTHRKO\nOPXLQUOROAINN\n" +
+                            "ZNPPAGIMLCHYO\nERURAABLHREDG\nPYETNUEZEFXSA\nAICGSLCDEHAPT\n" +
+                            "ROLPOINYBEGHN\nTELGRIPHUIOEE\nSURCLATYCONRP\nGALYLMECRJAEK\nMECZHFDIMARYP",
+                        wordBank: "",
+                        boggle: false,
+                        fuzzy: false,
+                    })}
+                />
+            </div>
+            <textarea
+                className="grid"
+                onChange={e => this.setState({ grid: e.target.value })}
+                value={this.state.grid}
+            />
+            <div>
+                {"Optional word bank (split by tab or newline; non-alphanumeric characters ignored): "}
+                <input
+                    type="button"
+                    value="Demo"
+                    onClick={() => this.setState({
+                        grid:
+                            "MENIMDLORAIREIMMUSKD\nWALUIGIGSOPAWTAADALH\nTERRNAEEWATOELRETTEC\n" +
+                            "ROIRODRIBYSFORIPOMEA\nANDILETTOPEACROFEINE\nCDRTPAMYWOCLHGTUEAHB\n" +
+                            "EANILASORSACLASATOCP\nWDFLSERYORNDORSSPEAH\nAYBOWSACTTOLVDENEOCB\n" +
+                            "PSRESSFFLEDAEKPIPOOO\nYSIADSEIOTESLSDGPIPK\nCROGDTONHFSONBNITOIU\n" +
+                            "ASTLAFSIOSETROMURGTC\nLIPEOSQOOBOTKEPLDAMR\nESEDSTUORRYYEFSDVIGI\n" +
+                            "RINRERAIDTERERNWVSYC\nTOADAIOCOKTGDSASOCNI\nHOSIUCTMNCKMOULTEBRE\n" +
+                            "RILLSEEOUSDLKINGBOOH\nDRREOTDTMALENRITAINS",
+                        wordBank:
+                            "Luigi Circuit\nMario Circuit\nDaisy Circuit\nDry Dry Ruins\n" +
+                            "Moo Moo Meadows\nCoconut Mall\nKoopa Cape\nMoonview Highway\n" +
+                            "Mushroom Gorge\nDK Summit\nMaple Treeway\nBowser's Castle\n" +
+                            "Toad's Factory\nWario's Gold Mine\nGrumble Volcano\nRainbow Road\n" +
+                            "Peach Beach\nSherbet Land\nDesert Hills\nMario Circuit\n" +
+                            "Yoshi Falls\nShy Guy Beach\nBowser Castle\nPeach Gardens\n" +
+                            "Ghost Valley\nDelfino Square\nDK's Jungle Parkway\nDK Mountain\n" +
+                            "Mario Raceway\nWaluigi Stadium\nMario Circuit\nBowser's Castle",
+                        boggle: true,
+                        fuzzy: false,
+                    })}
+                />
+            </div>
+            <textarea
+                className="word-bank"
+                onChange={e => this.setState({ wordBank: e.target.value })}
+                value={this.state.wordBank}
+            />
+            <div className="block">
+                <label>
+                    <input type="radio" checked={!boggle} onChange={() => this.setState({ boggle: false })} />
+                    {"Straight"}
+                </label>
+                <label>
+                    <input type="radio" checked={boggle} onChange={() => this.setState({ boggle: true })} />
+                    {"Boggle"}
+                </label>
+                <br />
+                <label>
+                    <input type="radio" checked={!fuzzy} onChange={() => this.setState({ fuzzy: false })} />
+                    {"Exact match"}
+                </label>
+                <label>
+                    <input type="radio" checked={fuzzy} onChange={() => this.setState({ fuzzy: true })} />
+                    {"Fuzzy match"}
+                </label>
+            </div>
+            <input type="button" value="Solve word search" onClick={this.solve} />
+            <br />
+            {loading ? <span className="loading" /> : undefined}
+        </>;
     }
 
-    hashStringToColor(str) {
-        let hash = 0;
-        for (let i = 0; i < str.length; i++) {
-            hash = str.charCodeAt(i) + ((hash << 5) - hash);
-        }
-        return `hsl(${hash % 359}, 50%, 75%)`;
+    renderSolvedGrid(gridSquareColors) {
+        const grid = this.getGrid();
+
+        return <>
+            <div className="block">
+                <span
+                    className="button"
+                    onClick={() => {
+                        this.setState({ editMode: true, selectedIds: [] });
+                        window.location.hash = "";
+                    }}
+                >
+                    {"< Edit grid"}
+                </span>
+            </div>
+            <div id="solved-grid">
+                <table className="block">
+                    <tbody>
+                        {grid.map((row, y) => <tr key={y}>
+                            {[...row].map((c, x) => <td key={x} style={{ backgroundColor: gridSquareColors[`${x}-${y}`] }}>
+                                {c}
+                            </td>)}
+                        </tr>)}
+                    </tbody>
+                </table>
+            </div>
+            <p>Unused letters:</p>
+            <textarea
+                className="unused-letters"
+                readOnly={true}
+                value={grid
+                    .flatMap((row, y) => [...row].filter((_, x) => gridSquareColors[`${x}-${y}`] === undefined))
+                    .join("")}
+            />
+        </>;
     }
 
-    onHighlightWordbankChange() {
-        const { highlightingAllWordbank, highlightingDifferentColors, results } = this.state;
-        const highlightedWords = {};
-        const highlightedPositions = {};
-        if (highlightingAllWordbank) {
-            results.filter(result => result.inWordBank).forEach(
-                ({ positions, word }, index
-            ) => {
-                const color = highlightingDifferentColors ? this.hashStringToColor(word) : '#f9ce70';
-                highlightedWords[index] = { color };
-                positions.forEach(({ x, y }) => {
-                    const key = `${x}-${y}`;
-                    if (!highlightedPositions.hasOwnProperty(key)) {
-                        highlightedPositions[key] = { color };
-                    }
-                });
-            });
-        }
-        this.setState({ highlightedPositions, highlightedWords, highlightedIndex: undefined });
-        this.hashLocation();
+    renderWordList(wordColors) {
+        const { results, loadingClipboard, hitLimit, selectedIds, isAdd } = this.state;
+
+        return <div className="output">
+            <div>
+                {"Click or drag over words to select them in the grid. "}
+                {selectedIds.length === 0
+                    ? <input
+                        type="button"
+                        value="Highlight all"
+                        onClick={() => this.setState({ selectedIds: results.map(result => result.id) })}
+                    />
+                    : <input
+                        type="button"
+                        value="Clear all"
+                        onClick={() => this.setState({ selectedIds: [] })}
+                    />}
+                <input
+                    type="button"
+                    value={loadingClipboard ? "Copied!" : "Copy results to clipboard"}
+                    onClick={this.copyResultsToClipboard}
+                />
+            </div>
+            <div>
+                {"Sort by: "}
+                <input
+                    type="button"
+                    value="Overall score"
+                    onClick={() => this.setState({
+                        results: results.sort((result1, result2) => result1.id - result2.id),
+                    })}
+                />
+                <input
+                    type="button"
+                    value="Length"
+                    onClick={() => this.setState({
+                        results: results.sort((result1, result2) => result2.word.length - result1.word.length),
+                    })}
+                />
+                {results.some(result => result.levenshteinDistance > 0) && <input
+                    type="button"
+                    value="Exact matches first"
+                    onClick={() => this.setState({
+                        results: results.sort((result1, result2) => result1.levenshteinDistance - result2.levenshteinDistance),
+                    })}
+                />}
+            </div>
+            {hitLimit && <div>{"Computation limit reached. Not all results are shown."}</div>}
+            <div id="word-list">
+                {results.map(({ id, word, levenshteinDistance }) => <div
+                    key={id}
+                    className="link"
+                    style={{ backgroundColor: wordColors[id] || '#f1f1f1' }}
+                    onMouseDown={() => {
+                        const isAdd = !selectedIds.includes(id);
+                        this.setState(prevState => ({
+                            selectedIds: isAdd
+                                ? [...prevState.selectedIds, id]
+                                : prevState.selectedIds.filter(selectedId => selectedId !== id),
+                            isAdd,
+                        }));
+                    }}
+                    onMouseUp={() => this.setState({ isAdd: undefined })}
+                    onMouseEnter={e => {
+                        this.setState(prevState => ({ ...prevState, hoveringId: id }))
+                        if (isAdd !== undefined && e.buttons === 1) {
+                            this.setState(prevState => ({
+                                selectedIds: isAdd
+                                    ? [...prevState.selectedIds, id]
+                                    : prevState.selectedIds.filter(i => i !== id),
+                            }));
+                        }
+                    }}
+                    onMouseLeave={() => this.setState(prevState => ({ ...prevState, hoveringId: undefined }))}
+                >{word}{levenshteinDistance > 0 ? '*' : ''}</div>)}
+            </div>
+        </div>
     }
 
     getGrid() {
-        return this.state.grid.trim().toUpperCase().split('\n').map(word => word.replace(/\s/g, ''));
+        return this.state.grid.toUpperCase().split('\n').map(line => line.replace(/\s/g, '')).filter(line => line !== '');
     }
 
-    getWordbank() {
-        return this.state.wordbank.trim().toUpperCase().split(/\n|\t/).map(word => word.replace(/[^A-Z0-9]/g, '')).filter(word => word.length >= 1);
+    getWordBank() {
+        return this.state.wordBank.toUpperCase().split(/\n|\t/).map(line => line.replace(/[^A-Z0-9]/g, '')).filter(line => line !== '');
     }
 
     solve = () => {
-        const { boggle } = this.state;
-        this.hashLocation();
+        const { grid, wordBank, boggle, fuzzy } = this.state;
+
+        window.location.hash = btoa(JSON.stringify({ grid, wordBank, boggle, fuzzy }));
+
         this.setState({ loading: true });
         postJson({
             path: '/words/search',
             body: {
                 grid: this.getGrid(),
-                wordBank: this.getWordbank(),
+                wordBank: this.getWordBank(),
                 boggle,
+                fuzzy,
             }
-        }, ({ results }) => {
-            this.setState({ editMode: false, results, highlightedPositions: {}, loading: false }, this.onHighlightWordbankChange);
-            if (!results.find(result => result.inWordBank)) {
-                this.setState({ highlightingAllWordbank: false });
-            }
+        }, ({ results, hitLimit }) => this.setState({
+            editMode: false,
+            results: results.map((result, i) => ({ ...result, id: i })),
+            hitLimit,
+            hoveringId: undefined,
+            loading: false,
+        }));
+    }
+
+    copyResultsToClipboard = () => {
+        const html = document.getElementById("solved-grid").innerHTML + document.getElementById("word-list").innerHTML;
+        const content = new Blob([html], { type: 'text/html' });
+        const data = [new window.ClipboardItem({ [content.type]: content })];
+        this.setState({ loadingClipboard: true });
+        navigator.clipboard.write(data).then(() => {
+            setTimeout(() => this.setState({ loadingClipboard: false }), 3000);
         });
     }
 }

--- a/snap-app/src/wordsearch/wordsearch.js
+++ b/snap-app/src/wordsearch/wordsearch.js
@@ -240,6 +240,9 @@ export default class Wordsearch extends React.Component {
                     key={id}
                     className="link"
                     style={{ backgroundColor: wordColors[id] || '#f1f1f1' }}
+
+                    // On mouse click, select the word if it's currently unselected, or unselect it otherwise.
+                    // When dragging, select or unselect the passed words based on whether the initial click was an add or remove.
                     onMouseDown={() => {
                         const isAdd = !selectedIds.includes(id);
                         this.setState(prevState => ({

--- a/snap-server/src/main/java/com/kyc/snap/api/WordsService.java
+++ b/snap-server/src/main/java/com/kyc/snap/api/WordsService.java
@@ -25,9 +25,11 @@ public interface WordsService {
     @Path("words/search")
     SolveWordSearchResponse solveWordSearch(SolveWordSearchRequest request);
 
-    record SolveWordSearchRequest(List<String> grid, Set<String> wordBank, boolean boggle) {}
+    record SolveWordSearchRequest(
+            List<String> grid, Set<String> wordBank, boolean boggle, boolean fuzzy) {}
 
-    record SolveWordSearchResponse(List<WordSearchSolver.Result> results) {}
+    record SolveWordSearchResponse(List<WordSearchSolver.Result> results, boolean hitLimit) {}
+
     @POST
     @Path("words/findCrossword")
     FindCrosswordResponse findCrossword(FindCrosswordRequest request);

--- a/snap-server/src/main/java/com/kyc/snap/server/SnapServer.java
+++ b/snap-server/src/main/java/com/kyc/snap/server/SnapServer.java
@@ -49,7 +49,7 @@ public class SnapServer extends Application<Configuration> {
         GridParser gridParser = new GridParser(openCv);
         CrosswordParser crosswordParser = new CrosswordParser();
         EnglishDictionary dictionary = new EnglishDictionary();
-        WordSearchSolver wordSearchSolver = new WordSearchSolver(dictionary);
+        WordSearchSolver wordSearchSolver = new WordSearchSolver();
         PregexSolver pregexSolver = new PregexSolver(new EnglishModel(dictionary));
         FileStore store = new FileStore();
 

--- a/snap-server/src/main/java/com/kyc/snap/words/CustomDictionary.java
+++ b/snap-server/src/main/java/com/kyc/snap/words/CustomDictionary.java
@@ -1,0 +1,26 @@
+package com.kyc.snap.words;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class CustomDictionary implements Dictionary {
+
+    private final SortedMap<String, Long> wordFrequencies = new TreeMap<>();
+
+    public CustomDictionary(Collection<String> words) {
+        for (String word : words)
+            wordFrequencies.put(word.toUpperCase().replaceAll("[^A-Z]+", ""), 1L);
+    }
+
+    @Override
+    public SortedMap<String, Long> getWordFrequencies() {
+        return wordFrequencies;
+    }
+
+    @Override
+    public Map<String, SortedMap<String, Long>> getBiWordFrequencies() {
+        return Map.of();
+    }
+}

--- a/snap-server/src/main/java/com/kyc/snap/words/EnglishTrie.java
+++ b/snap-server/src/main/java/com/kyc/snap/words/EnglishTrie.java
@@ -1,0 +1,63 @@
+package com.kyc.snap.words;
+
+import java.util.Collection;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.kyc.snap.solver.EnglishTokens;
+
+public class EnglishTrie {
+
+    private final Multimap<Integer, String> wordsByNodeIndex = ArrayListMultimap.create();
+    private int[][] nodes;
+    private int size = 1;
+
+    public static EnglishTrie of(Dictionary dictionary, int maxNumDeletions) {
+        EnglishTrie trie = new EnglishTrie();
+        for (String word : dictionary.getWords()) {
+            trie.add(word, word);
+
+            if (maxNumDeletions >= 1)
+                for (int i = 0; i < word.length(); i++)
+                    trie.add(word.substring(0, i) + word.substring(i + 1), word);
+        }
+        return trie;
+    }
+
+    private EnglishTrie() {
+        this.nodes = new int[1 << 20][EnglishTokens.NUM_LETTERS];
+    }
+
+    public int startNodeIndex() {
+        return 1;
+    }
+
+    public int getNodeIndex(int nodeIndex, char c) {
+        return nodeIndex < nodes.length ? nodes[nodeIndex][c - 'A'] : 0;
+    }
+
+    public Collection<String> getWords(int nodeIndex) {
+        return wordsByNodeIndex.get(nodeIndex);
+    }
+
+    private void add(String fuzzyWord, String word) {
+        int nodeIndex = startNodeIndex();
+        for (int i = 0; i < fuzzyWord.length(); i++) {
+            int index = fuzzyWord.charAt(i) - 'A';
+            ensureSize(nodeIndex);
+            if (nodes[nodeIndex][index] == 0)
+                nodes[nodeIndex][index] = ++size;
+            nodeIndex = nodes[nodeIndex][index];
+        }
+        wordsByNodeIndex.put(nodeIndex, word);
+    }
+
+    private void ensureSize(int nodeIndex) {
+        if (nodeIndex >= nodes.length) {
+            int[][] prevNodes = nodes;
+            nodes = new int[nodes.length * 2][nodes[0].length];
+            for (int i = 0; i < prevNodes.length; i++)
+                System.arraycopy(prevNodes[i], 0, nodes[i], 0, nodes[0].length);
+        }
+    }
+}

--- a/snap-server/src/main/java/com/kyc/snap/words/EnglishTrie.java
+++ b/snap-server/src/main/java/com/kyc/snap/words/EnglishTrie.java
@@ -8,6 +8,8 @@ import com.kyc.snap.solver.EnglishTokens;
 
 public class EnglishTrie {
 
+    public static final int NO_NODE = 0;
+
     private final Multimap<Integer, String> wordsByNodeIndex = ArrayListMultimap.create();
     private int[][] nodes;
     private int size = 1;
@@ -33,7 +35,7 @@ public class EnglishTrie {
     }
 
     public int getNodeIndex(int nodeIndex, char c) {
-        return nodeIndex < nodes.length ? nodes[nodeIndex][c - 'A'] : 0;
+        return nodeIndex < nodes.length ? nodes[nodeIndex][c - 'A'] : NO_NODE;
     }
 
     public Collection<String> getWords(int nodeIndex) {

--- a/snap-server/src/main/java/com/kyc/snap/words/StringUtil.java
+++ b/snap-server/src/main/java/com/kyc/snap/words/StringUtil.java
@@ -140,7 +140,7 @@ public enum StringUtil {
      * Find the Levenshtein distance between a and b.
      * https://en.wikipedia.org/wiki/Levenshtein_distance
      */
-    public static int levenshteinDistance(String a, String b) {
+    public static int levenshteinDistance(CharSequence a, CharSequence b) {
         int[] costs = new int[b.length() + 1];
         for (int j = 0; j <= b.length(); j++)
             costs[j] = j;

--- a/snap-server/src/main/java/com/kyc/snap/words/WordSearchSolver.java
+++ b/snap-server/src/main/java/com/kyc/snap/words/WordSearchSolver.java
@@ -1,76 +1,172 @@
 package com.kyc.snap.words;
 
 import java.awt.Point;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
-import com.google.common.base.Strings;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.Sets;
+import com.kyc.snap.solver.EnglishTokens;
 
-public record WordSearchSolver(EnglishDictionary dictionary) {
+public class WordSearchSolver {
 
-    private static final int MAX_RESULTS = 500;
+    private final Cache<List<Integer>, EnglishTrie> CACHED_ENGLISH_DICTIONARY_TRIES = Caffeine.newBuilder()
+            .maximumSize(3)
+            .build();
 
+    public AllResults find(
+            List<String> grid,
+            Dictionary dictionary,
+            boolean boggle,
+            List<Integer> minLengths) {
+        return find(
+                grid.stream()
+                        .map(String::toCharArray)
+                        .toArray(char[][]::new),
+                (currentPath, consumer) -> {
+                    if (currentPath.isEmpty()) {
+                        for (int y = 0; y < grid.size(); y++)
+                            for (int x = 0; x < grid.get(y).length(); x++)
+                                consumer.accept(new Point(x, y));
+                    } else if (boggle || currentPath.size() == 1) {
+                        for (int dx = -1; dx <= 1; dx++)
+                            for (int dy = -1; dy <= 1; dy++)
+                                consumer.accept(new Point(
+                                        currentPath.getLast().x + dx,
+                                        currentPath.getLast().y + dy));
+                    } else {
+                        Iterator<Point> it = currentPath.iterator();
+                        Point p0 = it.next();
+                        Point p1 = it.next();
+                        consumer.accept(new Point(
+                                currentPath.getLast().x + (p1.x - p0.x),
+                                currentPath.getLast().y + (p1.y - p0.y)));
+                    }
+                },
+                dictionary,
+                minLengths);
+    }
 
-    public List<Result> find(List<String> grid, Set<String> wordBank, boolean boggle) {
-        int width = grid.stream().mapToInt(String::length).max().orElse(0);
-        grid.replaceAll(s -> Strings.padEnd(s.toUpperCase(), width, '.'));
+    private AllResults find(
+            char[][] grid,
+            NeighborFunction neighborFunction,
+            Dictionary dictionary,
+            List<Integer> minLengths) {
+        for (char[] row : grid)
+            for (int i = 0; i < row.length; i++)
+                row[i] = Character.toUpperCase(row[i]);
 
-        Map<String, Long> wordFrequencies = dictionary.getWordFrequencies();
-        Set<String> words = Sets.union(wordFrequencies.keySet(), wordBank);
+        int maxNumDeletions = minLengths.size() - 1;
 
-        List<Point> positions = new ArrayList<>();
+        EnglishTrie trie = dictionary instanceof EnglishDictionary
+                ? CACHED_ENGLISH_DICTIONARY_TRIES.get(
+                        minLengths, _key -> EnglishTrie.of(dictionary, maxNumDeletions))
+                : EnglishTrie.of(dictionary, maxNumDeletions);
+
         List<Result> results = new ArrayList<>();
-        if (boggle) {
-            boolean[][] used = new boolean[grid.size()][width];
-            for (String word : words)
-                for (int i = 0; i < grid.size(); i++)
-                    for (int j = 0; j < width; j++)
-                        if (grid.get(i).charAt(j) == word.charAt(0))
-                            findBoggleHelper(grid, word, wordBank.contains(word), 1, i, j, positions, used, results);
-        } else {
-            for (int i = 0; i < grid.size(); i++)
-                for (int j = 0; j < width; j++)
-                    for (int di = -1; di <= 1; di++)
-                        for (int dj = -1; dj <= 1; dj++)
-                            if (di != 0 || dj != 0) {
-                                String word = "";
-                                for (int row = i, col = j; row >= 0 && row < grid.size() && col >= 0
-                                        && col < width; row += di, col += dj) {
-                                    word += grid.get(row).charAt(col);
-                                    positions.add(new Point(col, row));
-                                    if (word.length() >= 2 && words.contains(word))
-                                        results.add(new Result(word, new ArrayList<>(positions), wordBank.contains(word)));
-                                }
-                                positions.clear();
-                            }
-        }
-        return results.stream()
-                .sorted(Comparator.<Result, Boolean>comparing(result -> !result.inWordBank)
-                        .thenComparing(result -> (result.inWordBank ? -result.word.length() : -Math.sqrt(wordFrequencies.getOrDefault(result.word, 1L))) * Math.pow(26, result.word.length())))
-                .limit(MAX_RESULTS)
-                .toList();
+        int[] limit = {10000000};
+        new SolverInstance(
+                grid,
+                neighborFunction,
+                minLengths,
+                trie,
+                new ArrayDeque<>(),
+                new HashSet<>(),
+                new StringBuilder(),
+                new ArrayDeque<>(List.of(List.of(new State(trie.startNodeIndex(), 0)))),
+                results,
+                limit).run();
+        results.sort(Comparator.comparing(result -> -dictionary.getWordFrequencies().get(result.word)
+                * Math.pow(EnglishTokens.NUM_LETTERS, result.word.length() - 2 * result.levenshteinDistance)));
+
+        List<Result> filteredResults = new ArrayList<>();
+        for (Result result : results)
+            if (filteredResults.stream().allMatch(otherResult -> !result.word.equals(otherResult.word)
+                    || Sets.symmetricDifference(Set.copyOf(result.path), Set.copyOf(otherResult.path)).size() > 3)) {
+                filteredResults.add(result);
+                if (filteredResults.size() == 200)
+                    break;
+            }
+        return new AllResults(filteredResults, limit[0] == 0);
     }
 
-    private void findBoggleHelper(List<String> grid, String word, boolean inWordBank, int index, int row, int col, List<Point> positions, boolean[][] used,
-                                  List<Result> results) {
-        positions.add(new Point(col, row));
-        used[row][col] = true;
-        if (index == word.length()) {
-            results.add(new Result(word, new ArrayList<>(positions), inWordBank));
-        } else {
-            for (int nrow = row - 1; nrow <= row + 1; nrow++)
-                for (int ncol = col - 1; ncol <= col + 1; ncol++)
-                    if (nrow >= 0 && nrow < grid.size() && ncol >= 0 && ncol < grid.get(nrow).length()
-                            && !used[nrow][ncol] && grid.get(nrow).charAt(ncol) == word.charAt(index))
-                        findBoggleHelper(grid, word, inWordBank, index + 1, nrow, ncol, positions, used, results);
-        }
-        positions.remove(positions.size() - 1);
-        used[row][col] = false;
+    public record AllResults(List<Result> results, boolean hitLimit) {}
+
+    public record Result(List<Point> path, String word, int levenshteinDistance) {}
+
+    interface NeighborFunction {
+        void forEachNeighbor(Deque<Point> currentPath, Consumer<Point> consumer);
     }
 
-    public record Result(String word, List<Point> positions, boolean inWordBank) {}
+    private record SolverInstance(
+            char[][] grid,
+            NeighborFunction neighborFunction,
+            List<Integer> minLengths,
+            EnglishTrie trie,
+            Deque<Point> path,
+            Set<Point> points,
+            StringBuilder string,
+            Deque<List<State>> allStates,
+            List<Result> results,
+            int[] limit) {
+
+        void run() {
+            if (limit[0] == 0)
+                return;
+            limit[0]--;
+
+            if (allStates.getLast().isEmpty())
+                return;
+
+            for (State state : allStates.getLast())
+                for (String word : trie.getWords(state.nodeIndex)) {
+                    int d = StringUtil.levenshteinDistance(word, string);
+                    if (d < minLengths.size() && word.length() >= minLengths.get(d))
+                        results.add(new Result(List.copyOf(path), word, d));
+                }
+
+            neighborFunction.forEachNeighbor(path, neighbor -> {
+                if (neighbor.y >= 0
+                        && neighbor.y < grid.length
+                        && neighbor.x >= 0
+                        && neighbor.x < grid[neighbor.y].length
+                        && !points.contains(neighbor)) {
+                    char c = grid[neighbor.y][neighbor.x];
+                    if (c < 'A' || c > 'Z')
+                        return;
+
+                    path.add(neighbor);
+                    points.add(neighbor);
+                    string.append(c);
+
+                    List<State> newStates = new ArrayList<>();
+                    for (State state : allStates.getLast()) {
+                        int nodeIndex = trie.getNodeIndex(state.nodeIndex, c);
+                        if (nodeIndex != 0)
+                            newStates.add(new State(nodeIndex, state.numDeletions));
+                        if (state.numDeletions < minLengths.size() - 1)
+                            newStates.add(new State(state.nodeIndex, state.numDeletions + 1));
+                    }
+                    allStates.add(newStates);
+
+                    run();
+
+                    Point p = path.removeLast();
+                    points.remove(p);
+                    string.setLength(string.length() - 1);
+                    allStates.removeLast();
+                }
+            });
+        }
+    }
+
+    private record State(int nodeIndex, int numDeletions) {}
 }

--- a/snap-server/src/test/java/com/kyc/snap/solver/GenericSolverTest.java
+++ b/snap-server/src/test/java/com/kyc/snap/solver/GenericSolverTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class GenericSolverTest {
 
-    final EnglishModel model = new EnglishModel(new EnglishDictionary());
+    static final EnglishModel model = new EnglishModel(new EnglishDictionary());
 
     @Test
     public void anagram() {

--- a/snap-server/src/test/java/com/kyc/snap/words/WordSearchSolverTest.java
+++ b/snap-server/src/test/java/com/kyc/snap/words/WordSearchSolverTest.java
@@ -1,0 +1,44 @@
+package com.kyc.snap.words;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.kyc.snap.words.WordSearchSolver.Result;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WordSearchSolverTest {
+
+    static final EnglishDictionary dictionary = new EnglishDictionary();
+    static final WordSearchSolver solver = new WordSearchSolver();
+
+    @Test
+    public void findStraight() {
+        assertThat(solver.find(List.of("ABC", "DEF", "GHI"), dictionary, false, List.of(3)).results())
+                .extracting(Result::word)
+                .contains("FED")
+                .doesNotContain("BEG");
+    }
+
+    @Test
+    public void findBoggle() {
+        assertThat(solver.find(List.of("ABC", "DEF", "GHI"), dictionary, true, List.of(3)).results())
+                .extracting(Result::word)
+                .contains("FED", "BEG");
+    }
+
+    @Test
+    public void findFuzzy() {
+        assertThat(solver.find(List.of("AFB", "CUD", "EXF", "GZH", "IYJ"), dictionary, false, List.of(3, 5)).results())
+                .extracting(Result::word)
+                .contains("FUZZY");
+    }
+
+    @Test
+    public void findNotAlpha() {
+        assertThat(solver.find(List.of("ALPHA#"), dictionary, false, List.of(5)).results())
+                .extracting(Result::word)
+                .contains("ALPHA");
+    }
+}


### PR DESCRIPTION
I mainly wanted to support "fuzzy" matching, and then fixed/improved some other stuff alongside.

- (User) Support "fuzzy match" option. This also finds matches that are within 1 Levenshtein distance away of a word in the dictionary or the custom word bank. (2 is trivially extendable, but that gets to order of ~10s, which I don't want to expose on a server, but can be plugged in programmatically. 3+ gets infeasible because there are too many results.)
- (User) Remove "similar" duplicate results.
- (User) Allow selecting any subset of words to highlight in the grid.
- (User) Copy the word search grid (with any highlighted words) and the found word list to clipboard.
- (User) Support sorting by length or overall score (which accounts for both length and word frequency).
- (Dev) Support an entry point for word searches on an arbitrary graph network. Not clear what I would want to expose in a UI though, so this is not exposed as an endpoint.

Also removes some redundant functionality to simplify code:
- You can no longer search with the standard English dictionary and a custom word bank at the same time. It's easy to search them separately.
- It's no longer possible to highlight in the same color vs. different colors. Just always use different colors.